### PR TITLE
Modify URL.RawQuery only when necessary

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -16,7 +16,9 @@ func New() *PatternServeMux {
 func (p *PatternServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, ph := range p.handlers[r.Method] {
 		if params, ok := ph.try(r.URL.Path); ok {
-			r.URL.RawQuery = url.Values(params).Encode() + "&" + r.URL.RawQuery
+			if len(params) > 0 {
+				r.URL.RawQuery = url.Values(params).Encode() + "&" + r.URL.RawQuery
+			}
 			ph.ServeHTTP(w, r)
 			return
 		}
@@ -59,7 +61,7 @@ func (ph *patHandler) try(path string) (url.Values, bool) {
 			return nil, false
 		case ph.pat[j] == '*':
 			j++
-			val :=  path[i:]
+			val := path[i:]
 			p.Add(":splat", val)
 			i = len(path)
 		case ph.pat[j] == ':':

--- a/mux_test.go
+++ b/mux_test.go
@@ -90,3 +90,45 @@ func TestPatRoutingNoHit(t *testing.T) {
 	assert.T(t, !ok)
 	assert.Equal(t, http.StatusNotFound, rr.Code)
 }
+
+// Check to make sure we don't pollute the Raw Query when we have no parameters
+func TestPatNoParams(t *testing.T) {
+	p := New()
+
+	var ok bool
+	p.Get("/foo/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ok = true
+		t.Logf("%#v", r.URL.RawQuery)
+		assert.Equal(t, "", r.URL.RawQuery)
+	}))
+
+	r, err := http.NewRequest("GET", "/foo/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p.ServeHTTP(nil, r)
+
+	assert.T(t, ok)
+}
+
+// Check to make sure we don't pollute the Raw Query when there are parameters but no pattern variables
+func TestPatOnlyUserParams(t *testing.T) {
+	p := New()
+
+	var ok bool
+	p.Get("/foo/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ok = true
+		t.Logf("%#v", r.URL.RawQuery)
+		assert.Equal(t, "a=b", r.URL.RawQuery)
+	}))
+
+	r, err := http.NewRequest("GET", "/foo/?a=b", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p.ServeHTTP(nil, r)
+
+	assert.T(t, ok)
+}


### PR DESCRIPTION
Currently, we are prepending the pattern variables (:name, etc) in all cases.  Made a modification so this is only done when necessary.
