### PR TITLE
Fix slash match everything2

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -53,23 +53,23 @@ import (
 // A trivial example server is:
 //
 //	package main
-//	
+//
 //	import (
 //		"io"
 //		"net/http"
 //		"github.com/bmizerany/pat"
 //		"log"
 //	)
-//	
+//
 //	// hello world, the web server
 //	func HelloServer(w http.ResponseWriter, req *http.Request) {
 //		io.WriteString(w, "hello, "+req.URL.Query().Get(":name")+"!\n")
 //	}
-//	
+//
 //	func main() {
 //		m := pat.New()
 //		m.Get("/hello/:name", http.HandlerFunc(HelloServer))
-//	
+//
 //		// Register this pat with the default serve mux so that other packages
 //		// may also be exported. (i.e. /debug/pprof/*)
 //		http.Handle("/", m)
@@ -207,7 +207,7 @@ func (ph *patHandler) try(path string) (url.Values, bool) {
 	for i < len(path) {
 		switch {
 		case j >= len(ph.pat):
-			if ph.pat[len(ph.pat)-1] == '/' {
+			if ph.pat != "/" && len(ph.pat)-1 >= 0 && ph.pat[len(ph.pat)-1] == '/' {
 				return p, true
 			}
 			return nil, false

--- a/mux_test.go
+++ b/mux_test.go
@@ -11,7 +11,13 @@ import (
 )
 
 func TestPatMatch(t *testing.T) {
-	params, ok := (&patHandler{"/foo/:name", nil}).try("/foo/bar")
+	params, ok := (&patHandler{"/", nil}).try("/")
+	assert.Equal(t, true, ok)
+
+	params, ok = (&patHandler{"/", nil}).try("/wrong_url")
+	assert.Equal(t, false, ok)
+
+	params, ok = (&patHandler{"/foo/:name", nil}).try("/foo/bar")
 	assert.Equal(t, true, ok)
 	assert.Equal(t, url.Values{":name": {"bar"}}, params)
 


### PR DESCRIPTION
We should merge this binku87 commit, it fixes a panic with m.Get("/", http.HandlerFunc(...)) handlers :

2012/06/11 16:48:22 http: panic serving 127.0.0.1:36657: runtime error: index out of range
/usr/lib/go/src/pkg/net/http/server.go:576 (0x447bba)
_func_003: buf.Write(debug.Stack())
/build/buildd/golang-stable-1/src/pkg/runtime/proc.c:1443 (0x40fb00)
/build/buildd/golang-stable-1/src/pkg/runtime/runtime.c:128 (0x4105cc)
/build/buildd/golang-stable-1/src/pkg/runtime/runtime.c:85 (0x410473)
/home/alexis/go/src/github.com/zvin/pat/mux.go:217 (0x42756d)
com/zvin/pat.(_patHandler).try: if ph.pat[len(ph.pat)-1] == '/' {
/home/alexis/go/src/github.com/zvin/pat/mux.go:118 (0x426cc3)
com/zvin/pat.(_PatternServeMux).ServeHTTP: if _, ok := ph.try(r.URL.Path); ok {
/usr/lib/go/src/pkg/net/http/server.go:924 (0x43ca95)
(_ServeMux).ServeHTTP: mux.handler(r).ServeHTTP(w, r)
/usr/lib/go/src/pkg/net/http/server.go:656 (0x43ba26)
(_conn).serve: handler.ServeHTTP(w, w.req)
/build/buildd/golang-stable-1/src/pkg/runtime/proc.c:271 (0x40dc06)
