### PR TITLE
name match ends with any non-alnum char

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -78,6 +78,9 @@ func TestPatMatch(t *testing.T) {
 	assert.Equal(t, true, ok)
 	assert.Equal(t, url.Values{":": {"val1"}, ":name": {":val2"}}, params)
 
+	params, ok = (&patHandler{"/foo/:name.txt", nil}).try("/foo/bar/baz.txt")
+	assert.Equal(t, false, ok)
+
 	params, ok = (&patHandler{"/foo/x:name", nil}).try("/foo/bar")
 	assert.Equal(t, false, ok)
 


### PR DESCRIPTION
This gives much more flexibility in constructing patterns.

You can write `/:name.txt` and extract just the file
name, without the `.txt`. Another example, if you
want both the name and extension, it's `/:name.:ext`.

It would break any existing matches that contain
non-alphanumeric characters in the match name.
