### PR TITLE
Adding handler now updates a handler if registered

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -168,7 +168,16 @@ func (p *PatternServeMux) Options(pat string, h http.Handler) {
 
 // Add will register a pattern with a handler for meth requests.
 func (p *PatternServeMux) Add(meth, pat string, h http.Handler) {
-	p.handlers[meth] = append(p.handlers[meth], &patHandler{pat, h})
+	n := &patHandler{pat, h})
+	if m, ok := p.handlers[meth]; ok {
+		for i, p := range m {
+			if p.pat == pat {
+				p.handlers[meth][i] = n
+				return
+			}
+		}
+	}
+	p.handlers[meth] = append(p.handlers[meth], n) 
 
 	n := len(pat)
 	if n > 0 && pat[n-1] == '/' {

--- a/mux.go
+++ b/mux.go
@@ -168,16 +168,16 @@ func (p *PatternServeMux) Options(pat string, h http.Handler) {
 
 // Add will register a pattern with a handler for meth requests.
 func (p *PatternServeMux) Add(meth, pat string, h http.Handler) {
-	n := &patHandler{pat, h})
+	ph := &patHandler{pat, h}
 	if m, ok := p.handlers[meth]; ok {
-		for i, p := range m {
-			if p.pat == pat {
-				p.handlers[meth][i] = n
+		for i, patH := range m {
+			if patH.pat == pat {
+				p.handlers[meth][i] = ph
 				return
 			}
 		}
 	}
-	p.handlers[meth] = append(p.handlers[meth], n) 
+	p.handlers[meth] = append(p.handlers[meth], ph)
 
 	n := len(pat)
 	if n > 0 && pat[n-1] == '/' {


### PR DESCRIPTION
When a handler was added, there was no check whether the pattern was already registered. Now, if the pattern is registered, it is updated. It may be better to throw an error, or add a update flag, but for my use case, updating the handler is correct.

In any case, it is an error to add two handlers with same pattern.