### PR TITLE
Use EscapedPath for URL handling

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -244,6 +244,24 @@ func TestMethodPatch(t *testing.T) {
 	}
 }
 
+func TestEscapedUrl(t *testing.T) {
+	p := New()
+
+	var ok bool
+	p.Get("/foo/:name", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ok = true
+		t.Logf("%#v", r.URL.Query())
+		if got, want := r.URL.Query().Get(":name"), "bad/bear"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	}))
+
+	p.ServeHTTP(nil, newRequest("GET", "/foo/bad%2fbear?a=b", nil))
+	if !ok {
+		t.Error("handler not called")
+	}
+}
+
 func newRequest(method, urlStr string, body io.Reader) *http.Request {
 	req, err := http.NewRequest(method, urlStr, body)
 	if err != nil {


### PR DESCRIPTION
We encountered an issue where escaped slashes `%2f` were being unescaped and routed incorrectly.

This change defers unescaping the path until the parameters are extracted, rather than before routing.
