### PR TITLE
add Lookup and AllowedMethods methods, change custom NotFound semantics

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -309,8 +309,7 @@ func TestLookup(t *testing.T) {
 			t.Errorf("%s %s: lookup returned nil handler", r.method, r.path)
 		}
 		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("", "/", nil)
-		h.ServeHTTP(w, req)
+		h.ServeHTTP(w, newRequest("", "/", nil))
 		if w.Code != r.handlerIndex {
 			t.Errorf("%s %s: handler status code; got %v; want %v", r.method, r.path, w.Code, r.handlerIndex)
 		}

--- a/mux_test.go
+++ b/mux_test.go
@@ -213,11 +213,11 @@ func TestNotFound(t *testing.T) {
 	})
 	p.Post("/bar", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
-	for _, path := range []string{"/foo", "/bar"} {
+	for path, want := range map[string]int{"/foo": 123, "/bar": 405} {
 		res := httptest.NewRecorder()
 		p.ServeHTTP(res, newRequest("GET", path, nil))
-		if res.Code != 123 {
-			t.Errorf("for path %q: got code %d; want 123", path, res.Code)
+		if res.Code != want {
+			t.Errorf("for path %q: got code %d; want %d", path, res.Code, want)
 		}
 	}
 }


### PR DESCRIPTION
Hello,

I've used something like this fork of `pat` for a while, it adds two methods that can be very useful when building middleware chains:

- `AllowedMethods` : returns the allowed methods for a given path, useful esp. for a CORS middleware.
- `Lookup` : returns the matching registered handler for a given method and path, useful if in a middleware you want to check if the request actually has a handler before starting setting up the usual chain (e.g. logging, panic recover, cors, etc.)

I also made another change that may be a bit trickier to merge, I found it quite weird that setting a custom `NotFound` handler on the mux changed the way the 404 was returned. If there's no `NotFound` and a path has other methods registered, it returns a 405, and the 404 is only returned if there's no match and no other methods for the path. Once you set a custom NotFound handler, the behaviour changes and the 405 is not returned anymore (presumably it's because the custom not found should handle it? Still seems weird/unexpected). 

So this PR changes the behaviour so that setting a custom `NotFound` still behaves the same way as without it - it's just called if no 405 was returned. A case could probably be made to add support for a custom `MethodNotAllowed` handler, but I didn't add this.

I'm fine with keeping this stuff in my fork if you're not interested in adding more API surface to the package, no worries.

Thanks,
Martin