### PR TITLE
Add go.mod file for use with go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/bmizerany/pat
+
+go 1.16


### PR DESCRIPTION
This will also require a version tag be added to the repo for it to work properly in a project's own go.mod files.

(About the go version number: Ian explains it [here](https://github.com/golang/go/issues/30791#issuecomment-472217112). So it's safe to leave it as `go mod init` generated it.)